### PR TITLE
fix: 🐛 Fixed collapsible open logic

### DIFF
--- a/.changeset/bumpy-colts-say.md
+++ b/.changeset/bumpy-colts-say.md
@@ -1,0 +1,5 @@
+---
+"@adara-cs/ui-kit-web": patch
+---
+
+Fixed the Collapsible logic, in which content added a little later could be ignored in the height property, which led to its clipping in cases of opening.

--- a/packages/ui/src/components/Collapsible/Collapsible.tsx
+++ b/packages/ui/src/components/Collapsible/Collapsible.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FC, ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { FC, ReactNode, useCallback, useEffect, useState } from 'react';
 import { CollapsibleProvider } from './providers';
 import { useControlledState } from '@adara-cs/hooks';
 
@@ -30,32 +30,19 @@ export const Collapsible: FC<CollapsibleProps> = ({ open: controlledOpen, onChan
     onChangeHidden?.(hidden)
   }, [hidden, onChangeHidden])
 
-  const contentRef = useRef<HTMLDivElement>(null)
-  const wrapperRef = useRef<HTMLDivElement>(null)
-
-  useLayoutEffect(() => {
-    const wrapperNode = wrapperRef.current
-    const contentNode = contentRef.current
-
-    if (contentNode && wrapperNode) {
-      const rect = wrapperNode.getBoundingClientRect()
-      contentNode.style.setProperty('--content-height', rect.height + 'px')
-    }
-  }, []);
-
   const onOpenContent = useCallback(() => {
     setHidden(false)
     requestAnimationFrame(() => {
       onOpen()
     })
-  }, [open])
+  }, [onOpen])
 
   const onTransitionEnd = useCallback(() => {
     if (!open) setHidden(true)
   }, [open])
 
   return (
-    <CollapsibleProvider wrapperRef={wrapperRef} contentRef={contentRef} onTransitionEnd={onTransitionEnd} hidden={hidden} opened={open} onOpen={onOpenContent} onClose={onClose}>
+    <CollapsibleProvider onTransitionEnd={onTransitionEnd} hidden={hidden} opened={open} onOpen={onOpenContent} onClose={onClose}>
       {children}
     </CollapsibleProvider>
   )

--- a/packages/ui/src/components/Collapsible/components/CollapsibleContent/CollapsibleContent.tsx
+++ b/packages/ui/src/components/Collapsible/components/CollapsibleContent/CollapsibleContent.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DetailedHTMLProps, FC, HTMLAttributes, Ref } from 'react';
+import { DetailedHTMLProps, FC, HTMLAttributes, Ref, useLayoutEffect, useRef } from 'react';
 import style from './style.module.css';
 import { csx, mergeRefs } from '@adara-cs/utils';
 import { useCollapsibleContext } from '../../hooks';
@@ -15,7 +15,20 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   ref,
   children,
 }) => {
-  const { opened, onTransitionEnd, wrapperRef, contentRef, hidden } = useCollapsibleContext()
+  const contentRef = useRef<HTMLDivElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const { opened, onTransitionEnd, hidden } = useCollapsibleContext()
+
+  useLayoutEffect(() => {
+    const contentNode = contentRef.current
+    const wrapperNode = wrapperRef.current
+
+    if (contentNode && wrapperNode) {
+      const rectHeight = wrapperNode.getBoundingClientRect().height
+      contentNode.style.setProperty('--content-height', rectHeight + 'px')
+    }
+  });
 
   return (
     <div ref={mergeRefs([ref, contentRef])} data-type='content' data-open={opened} hidden={hidden} onTransitionEnd={onTransitionEnd} className={csx(style.content, className)}>

--- a/packages/ui/src/components/Collapsible/providers/CollapsibleProvider/CollapsibleProvider.tsx
+++ b/packages/ui/src/components/Collapsible/providers/CollapsibleProvider/CollapsibleProvider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FC, PropsWithChildren, Ref, TransitionEventHandler, useMemo } from 'react';
+import { FC, PropsWithChildren, TransitionEventHandler, useMemo } from 'react';
 import { CollapsibleContext } from './context.ts';
 
 interface CollapsibleProvider {
@@ -7,21 +7,17 @@ interface CollapsibleProvider {
   hidden: boolean
   onOpen: () => void
   onClose: () => void
-  contentRef?: Ref<HTMLDivElement>
-  wrapperRef?: Ref<HTMLDivElement>
   onTransitionEnd?: TransitionEventHandler<HTMLDivElement>
 }
 
-export const CollapsibleProvider: FC<PropsWithChildren<CollapsibleProvider>> = ({ opened, wrapperRef, contentRef, onTransitionEnd, hidden, onOpen, onClose, children }) => {
+export const CollapsibleProvider: FC<PropsWithChildren<CollapsibleProvider>> = ({ opened, onTransitionEnd, hidden, onOpen, onClose, children }) => {
   const value = useMemo(() => ({
     opened,
     hidden,
     open: onOpen,
     close: onClose,
-    wrapperRef,
-    contentRef,
     onTransitionEnd,
-  }), [opened, onOpen, onClose, hidden, wrapperRef, contentRef, onTransitionEnd])
+  }), [opened, onOpen, onClose, hidden, onTransitionEnd])
 
   return (
     <CollapsibleContext.Provider value={value}>

--- a/packages/ui/src/components/Collapsible/providers/CollapsibleProvider/defaultContext.ts
+++ b/packages/ui/src/components/Collapsible/providers/CollapsibleProvider/defaultContext.ts
@@ -1,12 +1,10 @@
-import { Ref, TransitionEventHandler } from 'react';
+import { TransitionEventHandler } from 'react';
 
 export interface DefaultCollapsibleContext {
   opened: boolean
   hidden: boolean
   open: VoidFunction,
   close: VoidFunction
-  contentRef?: Ref<HTMLDivElement>
-  wrapperRef?: Ref<HTMLDivElement>
   onTransitionEnd?: TransitionEventHandler<HTMLDivElement>
 }
 
@@ -15,7 +13,5 @@ export const defaultCollapsibleContext: DefaultCollapsibleContext = {
   hidden: true,
   open: () => undefined,
   close: () => undefined,
-  wrapperRef: undefined,
-  contentRef: undefined,
   onTransitionEnd: undefined
 }


### PR DESCRIPTION
Fixed the Collapsible logic, in which content added a little later could be ignored in the height property, which led to its clipping in cases of opening.