### PR TITLE
fix: 🐛 Fixed PinField

### DIFF
--- a/.changeset/mighty-socks-beam.md
+++ b/.changeset/mighty-socks-beam.md
@@ -1,0 +1,5 @@
+---
+"@adara-cs/ui-kit-web": patch
+---
+
+In some cases, when the entire Pin field was highlighted, the caret could appear on each of the highlighted fields, while it should be on only one. Also fixed a bug where it was impossible to select the end field.

--- a/packages/ui/src/components/PinField/components/PinFieldInput/PinFieldInput.tsx
+++ b/packages/ui/src/components/PinField/components/PinFieldInput/PinFieldInput.tsx
@@ -33,6 +33,7 @@ export const PinFieldInput: FC<PinFieldInputProps> = ({
   disabled,
   onSelectionRangeChange,
   onComplete,
+  onSelect: _onSelect,
   ...props
 }) => {
   const onSelect = (e: SyntheticEvent<HTMLInputElement, Event>) => {
@@ -42,6 +43,8 @@ export const PinFieldInput: FC<PinFieldInputProps> = ({
 
     const selectionStart = input.selectionDirection === 'forward' ? input.selectionStart : input.selectionEnd
     const selectionEnd = input.selectionDirection === 'forward' ? input.selectionEnd : input.selectionStart
+
+    _onSelect?.(e)
 
     if (selectionStart === null || selectionEnd === null) return
     if (selectionStart === selectionEnd) {

--- a/packages/ui/src/components/PinField/components/PinFieldSlot/PinFieldSlot.tsx
+++ b/packages/ui/src/components/PinField/components/PinFieldSlot/PinFieldSlot.tsx
@@ -24,7 +24,7 @@ export const PinFieldSlot: FC<PinFieldSlotProps> = ({ index }) => {
   const onClick = () => {
     if (!inputRef) return
 
-    if (index + 1 <= value.length) {
+    if (index <= value.length) {
       inputRef.current?.setSelectionRange(index, index + 1)
       onSelectionRangeChange?.([index, index + 1])
     }
@@ -43,6 +43,7 @@ export const PinFieldSlot: FC<PinFieldSlotProps> = ({ index }) => {
       onClick={onClick}
       className={csx(style.slot, slotClassName)}
       data-focus={selectionRange ? inRange(index, selectionRange) && inRange(index + 1, selectionRange) : false}
+      data-caret={index === selectionRange[0]}
       data-value={value[index]}
       data-disabled={disabled}
       data-error={error}

--- a/packages/ui/src/components/PinField/style.module.css
+++ b/packages/ui/src/components/PinField/style.module.css
@@ -17,7 +17,7 @@
     z-index: -1;
 }
 
-.inputWrapper:has(.input:focus) .inputPinBlock[data-focus='true']:not([data-value]):before {
+.inputWrapper:has(.input:focus) .inputPinBlock[data-caret='true']:not([data-value]):before {
     visibility: visible;
 }
 


### PR DESCRIPTION
In some cases, when the entire Pin field was highlighted, the caret could appear on each of the highlighted fields, while it should be on only one. Also fixed a bug where it was impossible to select the end field.