### PR TITLE
Potential fix for code scanning alert no. 2: Overly permissive regular expression range

### DIFF
--- a/packages/ui/src/components/PinField/PinField.stories.tsx
+++ b/packages/ui/src/components/PinField/PinField.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
 
 export const WithAlphabet: Story = {
   args: {
-    mask: /^[A-z]+$/,
+    mask: /^[A-Za-z]+$/,
     children: [
       <PinFieldSlot index={0} />,
       <PinFieldSlot index={1} />,


### PR DESCRIPTION
Potential fix for [https://github.com/adara-cs/ui-kit-web/security/code-scanning/2](https://github.com/adara-cs/ui-kit-web/security/code-scanning/2)

To fix the problem, we need to correct the regular expression to match only the intended alphabetic characters. The best way to do this is to replace the range `A-z` with two separate ranges: `A-Z` for uppercase letters and `a-z` for lowercase letters. This ensures that only alphabetic characters are matched.

- Change the regular expression on line 41 from `/^[A-z]+$/` to `/^[A-Za-z]+$/`.
- This change is localized to a single line and does not affect the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
